### PR TITLE
ci: Change to using ubuntu 22.04 for linting, due to more up to date …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Run clang-format


### PR DESCRIPTION
…clang-format version.